### PR TITLE
make dispatch return Router.run Promise for transitionTo actions

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -243,7 +243,7 @@ export default class Router {
                 reject(err);
             };
 
-            resolveWithFirstMatched(this.routes, path, query).then(
+            return resolveWithFirstMatched(this.routes, path, query).then(
                 runResolvedRoute,
                 notFound
             );

--- a/src/createRoutex.js
+++ b/src/createRoutex.js
@@ -41,7 +41,7 @@ export default function createRoutex(routes, history, onTransition) {
                 return nextStore.dispatch(action);
             }
 
-            router.run(action.pathname, action.query);
+            return router.run(action.pathname, action.query);
         }
 
         // register listeners


### PR DESCRIPTION
It comes in handy on the server, where we need to know when the router has completed its transition to a route before being able to call React's `renderTo[String|StaticMarkup]` methods.

Coupled with async/await it enables this kind of flow:
```js
try {
  await store.dispatch(routexActions.transitionTo(req.url));
} catch (e) {
  let status = 500;
  if (e instanceof RouteNotFoundError) {
    status = 404;
  } else if (e instanceof MyApiError) {
    status = e.status;
  }
  await store.dispatch(routexActions.transitionTo(`/${status}`));
}

const html = React.renderToString(
  <Provider store={store}>
      {() => <View />}
  </Provider>
);
```

Something similar can be achieved with the `onTransition` callback, but I think this is also a valid and nice way to handle 404's and any other app exception that might occur during routing.